### PR TITLE
recipe: add OpenMP threadprivate test

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,31 +8,30 @@ jobs:
     vmImage: ubuntu-16.04
   strategy:
     matrix:
-      linux_64_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-64:
-        CONFIG: linux_64_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-64
+      linux_64_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0:
+        CONFIG: linux_64_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
-      linux_64_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-64:
-        CONFIG: linux_64_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0:
+        CONFIG: linux_64_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
-      linux_64_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-64:
-        CONFIG: linux_64_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0:
+        CONFIG: linux_64_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
-      linux_64_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-64:
-        CONFIG: linux_64_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0:
+        CONFIG: linux_64_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
-      linux_64_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-64:
-        CONFIG: linux_64_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0:
+        CONFIG: linux_64_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
-      linux_64_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-64:
-        CONFIG: linux_64_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
+      linux_64_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0:
+        CONFIG: linux_64_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
-    maxParallel: 8
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,28 +8,27 @@ jobs:
     vmImage: macOS-10.15
   strategy:
     matrix:
-      osx_64_cross_target_platformosx-64gfortran_version11.0.0target_platformosx-64:
-        CONFIG: osx_64_cross_target_platformosx-64gfortran_version11.0.0target_platformosx-64
+      osx_64_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0:
+        CONFIG: osx_64_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-64gfortran_version7.5.0target_platformosx-64:
-        CONFIG: osx_64_cross_target_platformosx-64gfortran_version7.5.0target_platformosx-64
+      osx_64_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0:
+        CONFIG: osx_64_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-64gfortran_version9.3.0target_platformosx-64:
-        CONFIG: osx_64_cross_target_platformosx-64gfortran_version9.3.0target_platformosx-64
+      osx_64_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0:
+        CONFIG: osx_64_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-arm64gfortran_version11.0.0target_platformosx-64:
-        CONFIG: osx_64_cross_target_platformosx-arm64gfortran_version11.0.0target_platformosx-64
+      osx_64_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0:
+        CONFIG: osx_64_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-arm64gfortran_version7.5.0target_platformosx-64:
-        CONFIG: osx_64_cross_target_platformosx-arm64gfortran_version7.5.0target_platformosx-64
+      osx_64_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0:
+        CONFIG: osx_64_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0
         UPLOAD_PACKAGES: 'True'
-      osx_64_cross_target_platformosx-arm64gfortran_version9.3.0target_platformosx-64:
-        CONFIG: osx_64_cross_target_platformosx-arm64gfortran_version9.3.0target_platformosx-64
+      osx_64_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0:
+        CONFIG: osx_64_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_cross_target_platformosx-arm64gfortran_version11.0.0target_platformosx-arm64:
-        CONFIG: osx_arm64_cross_target_platformosx-arm64gfortran_version11.0.0target_platformosx-arm64
+      osx_arm64_cross_target_platformosx-arm64gfortran_version11.0.0:
+        CONFIG: osx_arm64_cross_target_platformosx-arm64gfortran_version11.0.0
         UPLOAD_PACKAGES: 'True'
-    maxParallel: 8
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0.yaml
@@ -1,25 +1,21 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.5'
-cdt_arch:
-- aarch64
+- '9'
 cdt_name:
-- cos7
+- cos6
 channel_sources:
-- conda-forge
+- conda-forge,defaults
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-arm64
+- osx-64
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.5'
+- '9'
 docker_image:
-- condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-comp7
 gfortran_version:
 - 11.0.0
 gmp:
@@ -29,7 +25,7 @@ isl:
 libiconv:
 - '1.16'
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 mpfr:
 - '4'
 pin_run_as_build:
@@ -44,8 +40,10 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.ci_support/linux_64_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0.yaml
@@ -1,19 +1,21 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '8'
+- '9'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-arm64
+- osx-64
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '8'
+- '9'
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-comp7
 gfortran_version:
 - 7.5.0
 gmp:
@@ -23,7 +25,7 @@ isl:
 libiconv:
 - '1.16'
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 mpfr:
 - '4'
 pin_run_as_build:
@@ -38,8 +40,10 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 target_platform:
-- linux-ppc64le
+- linux-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.ci_support/linux_64_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0.yaml
@@ -1,21 +1,23 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '9'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-arm64
+- osx-64
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '9'
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 gfortran_version:
-- 7.5.0
+- 9.3.0
 gmp:
 - '6'
 isl:
@@ -23,7 +25,7 @@ isl:
 libiconv:
 - '1.16'
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 mpfr:
 - '4'
 pin_run_as_build:
@@ -40,6 +42,8 @@ pin_run_as_build:
 target_platform:
 - linux-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.ci_support/linux_64_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0.yaml
@@ -1,21 +1,23 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '9'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-64
+- osx-arm64
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '9'
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 gfortran_version:
-- 9.3.0
+- 11.0.0
 gmp:
 - '6'
 isl:
@@ -23,7 +25,7 @@ isl:
 libiconv:
 - '1.16'
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 mpfr:
 - '4'
 pin_run_as_build:
@@ -40,6 +42,8 @@ pin_run_as_build:
 target_platform:
 - linux-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.ci_support/linux_64_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0.yaml
@@ -1,21 +1,23 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '10'
+- '9'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-64
+- osx-arm64
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '10'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-comp7
 gfortran_version:
-- 11.0.0
+- 7.5.0
 gmp:
 - '6'
 isl:
@@ -23,7 +25,7 @@ isl:
 libiconv:
 - '1.16'
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 mpfr:
 - '4'
 pin_run_as_build:
@@ -38,8 +40,10 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.ci_support/linux_64_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0.yaml
+++ b/.ci_support/linux_64_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0.yaml
@@ -1,19 +1,21 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '8'
+- '9'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-64
+- osx-arm64
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '8'
+- '9'
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-comp7
 gfortran_version:
 - 9.3.0
 gmp:
@@ -23,7 +25,7 @@ isl:
 libiconv:
 - '1.16'
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 mpfr:
 - '4'
 pin_run_as_build:
@@ -38,8 +40,10 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 target_platform:
-- linux-ppc64le
+- linux-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.ci_support/linux_aarch64_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0.yaml
@@ -1,21 +1,27 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '9'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-arm64
+- osx-64
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '9'
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-aarch64
 gfortran_version:
-- 9.3.0
+- 11.0.0
 gmp:
 - '6'
 isl:
@@ -23,7 +29,7 @@ isl:
 libiconv:
 - '1.16'
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 mpfr:
 - '4'
 pin_run_as_build:
@@ -38,8 +44,10 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.ci_support/linux_aarch64_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.5'
+- '9'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,11 +17,11 @@ cross_target_platform:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.5'
+- '9'
 docker_image:
-- condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-aarch64
 gfortran_version:
-- 9.3.0
+- 7.5.0
 gmp:
 - '6'
 isl:
@@ -46,6 +46,8 @@ pin_run_as_build:
 target_platform:
 - linux-aarch64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.ci_support/linux_aarch64_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0.yaml
@@ -1,9 +1,15 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
-- '8'
+- '9'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
@@ -11,11 +17,11 @@ cross_target_platform:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '8'
+- '9'
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-aarch64
 gfortran_version:
-- 11.0.0
+- 9.3.0
 gmp:
 - '6'
 isl:
@@ -38,8 +44,10 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 target_platform:
-- linux-ppc64le
+- linux-aarch64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.ci_support/linux_aarch64_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0.yaml
@@ -1,21 +1,27 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '10'
+- '9'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-64
+- osx-arm64
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '10'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
 gfortran_version:
-- 7.5.0
+- 11.0.0
 gmp:
 - '6'
 isl:
@@ -23,7 +29,7 @@ isl:
 libiconv:
 - '1.16'
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 mpfr:
 - '4'
 pin_run_as_build:
@@ -38,8 +44,10 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 target_platform:
-- osx-64
+- linux-aarch64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.ci_support/linux_aarch64_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.5'
+- '9'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,9 +17,9 @@ cross_target_platform:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.5'
+- '9'
 docker_image:
-- condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-aarch64
 gfortran_version:
 - 7.5.0
 gmp:
@@ -46,6 +46,8 @@ pin_run_as_build:
 target_platform:
 - linux-aarch64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.ci_support/linux_aarch64_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0.yaml
+++ b/.ci_support/linux_aarch64_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0.yaml
@@ -1,9 +1,15 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
-- '8'
+- '9'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
@@ -11,9 +17,9 @@ cross_target_platform:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '8'
+- '9'
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-aarch64
 gfortran_version:
 - 9.3.0
 gmp:
@@ -38,8 +44,10 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 target_platform:
-- linux-ppc64le
+- linux-aarch64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.ci_support/linux_ppc64le_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0.yaml
@@ -1,21 +1,23 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '10'
+- '9'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-arm64
+- osx-64
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '10'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
 gfortran_version:
-- 9.3.0
+- 11.0.0
 gmp:
 - '6'
 isl:
@@ -23,7 +25,7 @@ isl:
 libiconv:
 - '1.16'
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 mpfr:
 - '4'
 pin_run_as_build:
@@ -38,8 +40,10 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 target_platform:
-- osx-64
+- linux-ppc64le
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.ci_support/linux_ppc64le_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0.yaml
@@ -1,27 +1,23 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.5'
-cdt_arch:
-- aarch64
+- '9'
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge
+- conda-forge,defaults
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-arm64
+- osx-64
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.5'
+- '9'
 docker_image:
-- condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-ppc64le
 gfortran_version:
-- 9.3.0
+- 7.5.0
 gmp:
 - '6'
 isl:
@@ -29,7 +25,7 @@ isl:
 libiconv:
 - '1.16'
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 mpfr:
 - '4'
 pin_run_as_build:
@@ -44,8 +40,10 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 target_platform:
-- linux-aarch64
+- linux-ppc64le
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.ci_support/linux_ppc64le_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0.yaml
@@ -1,21 +1,23 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '11'
+- '9'
+cdt_name:
+- cos7
 channel_sources:
-- conda-forge/label/llvm_rc,conda-forge,https://conda-web.anaconda.org/conda-forge
+- conda-forge,defaults
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-arm64
+- osx-64
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '11'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
 gfortran_version:
-- 11.0.0
+- 9.3.0
 gmp:
 - '6'
 isl:
@@ -23,7 +25,7 @@ isl:
 libiconv:
 - '1.16'
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 mpfr:
 - '4'
 pin_run_as_build:
@@ -38,8 +40,10 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 target_platform:
-- osx-arm64
+- linux-ppc64le
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.ci_support/linux_ppc64le_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0.yaml
@@ -1,7 +1,9 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '8'
+- '9'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -11,9 +13,9 @@ cross_target_platform:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '8'
+- '9'
 docker_image:
-- condaforge/linux-anvil-ppc64le
+- quay.io/condaforge/linux-anvil-ppc64le
 gfortran_version:
 - 11.0.0
 gmp:
@@ -40,6 +42,8 @@ pin_run_as_build:
 target_platform:
 - linux-ppc64le
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.ci_support/linux_ppc64le_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0.yaml
@@ -1,25 +1,21 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.5'
-cdt_arch:
-- aarch64
+- '9'
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge
+- conda-forge,defaults
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-64
+- osx-arm64
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.5'
+- '9'
 docker_image:
-- condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-ppc64le
 gfortran_version:
 - 7.5.0
 gmp:
@@ -29,7 +25,7 @@ isl:
 libiconv:
 - '1.16'
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 mpfr:
 - '4'
 pin_run_as_build:
@@ -44,8 +40,10 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 target_platform:
-- linux-aarch64
+- linux-ppc64le
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.ci_support/linux_ppc64le_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0.yaml
+++ b/.ci_support/linux_ppc64le_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0.yaml
@@ -1,9 +1,9 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '10'
+- '9'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -11,11 +11,13 @@ channel_targets:
 cross_target_platform:
 - osx-arm64
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '10'
+- '9'
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
 gfortran_version:
-- 11.0.0
+- 9.3.0
 gmp:
 - '6'
 isl:
@@ -38,8 +40,10 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 target_platform:
-- osx-64
+- linux-ppc64le
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.ci_support/osx_64_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0.yaml
@@ -1,7 +1,9 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '8'
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -9,13 +11,11 @@ channel_targets:
 cross_target_platform:
 - osx-64
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '8'
-docker_image:
-- condaforge/linux-anvil-ppc64le
+- '11'
 gfortran_version:
-- 7.5.0
+- 11.0.0
 gmp:
 - '6'
 isl:
@@ -38,8 +38,10 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 target_platform:
-- linux-ppc64le
+- osx-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.ci_support/osx_64_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0.yaml
@@ -3,17 +3,17 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '10'
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-arm64
+- osx-64
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '10'
+- '11'
 gfortran_version:
 - 7.5.0
 gmp:
@@ -23,7 +23,7 @@ isl:
 libiconv:
 - '1.16'
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 mpfr:
 - '4'
 pin_run_as_build:
@@ -40,6 +40,8 @@ pin_run_as_build:
 target_platform:
 - osx-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.ci_support/osx_64_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0.yaml
@@ -1,21 +1,21 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '7'
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-arm64
+- osx-64
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '7'
-docker_image:
-- condaforge/linux-anvil-comp7
+- '11'
 gfortran_version:
-- 11.0.0
+- 9.3.0
 gmp:
 - '6'
 isl:
@@ -23,7 +23,7 @@ isl:
 libiconv:
 - '1.16'
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 mpfr:
 - '4'
 pin_run_as_build:
@@ -38,8 +38,10 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.ci_support/osx_64_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0.yaml
@@ -1,19 +1,19 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '7'
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-64
+- osx-arm64
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '7'
-docker_image:
-- condaforge/linux-anvil-comp7
+- '11'
 gfortran_version:
 - 11.0.0
 gmp:
@@ -23,7 +23,7 @@ isl:
 libiconv:
 - '1.16'
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 mpfr:
 - '4'
 pin_run_as_build:
@@ -38,8 +38,10 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.ci_support/osx_64_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0.yaml
@@ -1,19 +1,19 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '7'
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-64
+- osx-arm64
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '7'
-docker_image:
-- condaforge/linux-anvil-comp7
+- '11'
 gfortran_version:
 - 7.5.0
 gmp:
@@ -23,7 +23,7 @@ isl:
 libiconv:
 - '1.16'
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 mpfr:
 - '4'
 pin_run_as_build:
@@ -38,8 +38,10 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.ci_support/osx_64_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0.yaml
+++ b/.ci_support/osx_64_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0.yaml
@@ -1,27 +1,21 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '7.5'
-cdt_arch:
-- aarch64
-cdt_name:
-- cos7
+- '11'
 channel_sources:
-- conda-forge
+- conda-forge,defaults
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-64
+- osx-arm64
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '7.5'
-docker_image:
-- condaforge/linux-anvil-aarch64
+- '11'
 gfortran_version:
-- 11.0.0
+- 9.3.0
 gmp:
 - '6'
 isl:
@@ -29,7 +23,7 @@ isl:
 libiconv:
 - '1.16'
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 mpfr:
 - '4'
 pin_run_as_build:
@@ -44,8 +38,10 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 target_platform:
-- linux-aarch64
+- osx-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.ci_support/osx_arm64_cross_target_platformosx-arm64gfortran_version11.0.0.yaml
+++ b/.ci_support/osx_arm64_cross_target_platformosx-arm64gfortran_version11.0.0.yaml
@@ -1,21 +1,21 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '11.0'
 c_compiler:
 - clang
 c_compiler_version:
-- '10'
+- '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge/label/rust_dev,conda-forge
 channel_targets:
 - conda-forge main
 cross_target_platform:
-- osx-64
+- osx-arm64
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '10'
+- '11'
 gfortran_version:
-- 9.3.0
+- 11.0.0
 gmp:
 - '6'
 isl:
@@ -23,7 +23,7 @@ isl:
 libiconv:
 - '1.16'
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 mpfr:
 - '4'
 pin_run_as_build:
@@ -38,8 +38,10 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 target_platform:
-- osx-64
+- osx-arm64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cross_target_platform
   - macos_machine
 zlib:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 ---
 kind: pipeline
-name: linux_aarch64_cross_target_platform_h767f285705
+name: linux_aarch64_cross_target_platform_h4f7e4bf3a4
 
 platform:
   os: linux
@@ -8,9 +8,9 @@ platform:
 
 steps:
 - name: Install and build
-  image: condaforge/linux-anvil-aarch64
+  image: quay.io/condaforge/linux-anvil-aarch64
   environment:
-    CONFIG: linux_aarch64_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-aarch64
+    CONFIG: linux_aarch64_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0
     UPLOAD_PACKAGES: True
     PLATFORM: linux-aarch64
     BINSTAR_TOKEN:
@@ -31,7 +31,7 @@ steps:
 
 ---
 kind: pipeline
-name: linux_aarch64_cross_target_platform_ha14b0a3189
+name: linux_aarch64_cross_target_platform_ha490cb05b8
 
 platform:
   os: linux
@@ -39,9 +39,9 @@ platform:
 
 steps:
 - name: Install and build
-  image: condaforge/linux-anvil-aarch64
+  image: quay.io/condaforge/linux-anvil-aarch64
   environment:
-    CONFIG: linux_aarch64_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-aarch64
+    CONFIG: linux_aarch64_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0
     UPLOAD_PACKAGES: True
     PLATFORM: linux-aarch64
     BINSTAR_TOKEN:
@@ -62,7 +62,7 @@ steps:
 
 ---
 kind: pipeline
-name: linux_aarch64_cross_target_platform_h79fad72d73
+name: linux_aarch64_cross_target_platform_h4edbf53530
 
 platform:
   os: linux
@@ -70,9 +70,9 @@ platform:
 
 steps:
 - name: Install and build
-  image: condaforge/linux-anvil-aarch64
+  image: quay.io/condaforge/linux-anvil-aarch64
   environment:
-    CONFIG: linux_aarch64_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-aarch64
+    CONFIG: linux_aarch64_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0
     UPLOAD_PACKAGES: True
     PLATFORM: linux-aarch64
     BINSTAR_TOKEN:
@@ -93,7 +93,7 @@ steps:
 
 ---
 kind: pipeline
-name: linux_aarch64_cross_target_platform_h083dba320f
+name: linux_aarch64_cross_target_platform_h72b6c8165c
 
 platform:
   os: linux
@@ -101,9 +101,9 @@ platform:
 
 steps:
 - name: Install and build
-  image: condaforge/linux-anvil-aarch64
+  image: quay.io/condaforge/linux-anvil-aarch64
   environment:
-    CONFIG: linux_aarch64_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-aarch64
+    CONFIG: linux_aarch64_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0
     UPLOAD_PACKAGES: True
     PLATFORM: linux-aarch64
     BINSTAR_TOKEN:
@@ -124,7 +124,7 @@ steps:
 
 ---
 kind: pipeline
-name: linux_aarch64_cross_target_platform_h60d3bae2d9
+name: linux_aarch64_cross_target_platform_h44b9a6648b
 
 platform:
   os: linux
@@ -132,9 +132,9 @@ platform:
 
 steps:
 - name: Install and build
-  image: condaforge/linux-anvil-aarch64
+  image: quay.io/condaforge/linux-anvil-aarch64
   environment:
-    CONFIG: linux_aarch64_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-aarch64
+    CONFIG: linux_aarch64_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0
     UPLOAD_PACKAGES: True
     PLATFORM: linux-aarch64
     BINSTAR_TOKEN:
@@ -155,7 +155,7 @@ steps:
 
 ---
 kind: pipeline
-name: linux_aarch64_cross_target_platform_hd749ba29a2
+name: linux_aarch64_cross_target_platform_ha7a4fefcb2
 
 platform:
   os: linux
@@ -163,9 +163,9 @@ platform:
 
 steps:
 - name: Install and build
-  image: condaforge/linux-anvil-aarch64
+  image: quay.io/condaforge/linux-anvil-aarch64
   environment:
-    CONFIG: linux_aarch64_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-aarch64
+    CONFIG: linux_aarch64_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0
     UPLOAD_PACKAGES: True
     PLATFORM: linux-aarch64
     BINSTAR_TOKEN:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -19,7 +19,7 @@ conda-build:
 
 CONDARC
 
-conda install --yes --quiet conda-forge-ci-setup=3 conda-build pip -c conda-forge
+conda install --yes --quiet "conda-forge-ci-setup=3" conda-build pip -c conda-forge
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -33,13 +33,25 @@ if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
      EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
 fi
 
-conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-    --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-    --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-validate_recipe_outputs "${FEEDSTOCK_NAME}"
 
-if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-    upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
+    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
+    fi
+    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        ${EXTRA_CB_OPTIONS:-} \
+        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+    # Drop into an interactive shell
+    /bin/bash
+else
+    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
+        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+    validate_recipe_outputs "${FEEDSTOCK_NAME}"
+
+    if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
+        upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+    fi
 fi
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -74,6 +74,8 @@ docker run ${DOCKER_RUN_ARGS} \
            -e CI \
            -e FEEDSTOCK_NAME \
            -e CPU_COUNT \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e BUILD_OUTPUT_ID \
            -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -23,7 +23,7 @@ source ${HOME}/miniforge3/etc/profile.d/conda.sh
 conda activate base
 
 echo -e "\n\nInstalling conda-forge-ci-setup=3 and conda-build."
-conda install -n base --quiet --yes conda-forge-ci-setup=3 conda-build pip
+conda install -n base --quiet --yes "conda-forge-ci-setup=3" conda-build pip
 
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,27 +7,27 @@ language: generic
 
 matrix:
   include:
-    - env: CONFIG=linux_ppc64le_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-ppc64le UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0 UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 
-    - env: CONFIG=linux_ppc64le_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-ppc64le UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0 UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 
-    - env: CONFIG=linux_ppc64le_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-ppc64le UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0 UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 
-    - env: CONFIG=linux_ppc64le_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-ppc64le UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0 UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 
-    - env: CONFIG=linux_ppc64le_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-ppc64le UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0 UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 
-    - env: CONFIG=linux_ppc64le_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-ppc64le UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+    - env: CONFIG=linux_ppc64le_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0 UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=quay.io/condaforge/linux-anvil-ppc64le
       os: linux
       arch: ppc64le
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
-About gfortran_impl_osx-64
-==========================
+About gfortran_impl_osx-arm64
+=============================
 
 Home: http://gcc.gnu.org/
 
 Package license: GPL-3.0-only WITH GCC-exception-3.1
 
-Feedstock license: BSD-3-Clause
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/gfortran_impl_osx-64-feedstock/blob/master/LICENSE.txt)
 
 Summary: Fortran compiler and libraries from the GNU Compiler Collection
-
-
 
 Current build status
 ====================
@@ -43,178 +41,178 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-64</td>
+              <td>linux_64_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_64_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_64_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-64</td>
+              <td>linux_64_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_64_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_64_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-64</td>
+              <td>linux_64_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_64_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_64_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-64</td>
+              <td>linux_64_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_64_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_64_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-64</td>
+              <td>linux_64_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_64_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_64_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-64</td>
+              <td>linux_64_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_64_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_64_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-aarch64</td>
+              <td>linux_aarch64_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-aarch64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-aarch64</td>
+              <td>linux_aarch64_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-aarch64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-aarch64</td>
+              <td>linux_aarch64_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-aarch64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-aarch64</td>
+              <td>linux_aarch64_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-aarch64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-aarch64</td>
+              <td>linux_aarch64_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-aarch64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-aarch64</td>
+              <td>linux_aarch64_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-aarch64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-ppc64le</td>
+              <td>linux_ppc64le_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-ppc64le" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-ppc64le</td>
+              <td>linux_ppc64le_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-ppc64le" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-ppc64le</td>
+              <td>linux_ppc64le_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0target_platformlinux-ppc64le" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-ppc64le</td>
+              <td>linux_ppc64le_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-ppc64le" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-ppc64le</td>
+              <td>linux_ppc64le_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-ppc64le" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-ppc64le</td>
+              <td>linux_ppc64le_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0target_platformlinux-ppc64le" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-64gfortran_version11.0.0target_platformosx-64</td>
+              <td>osx_64_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=osx&configuration=osx_64_cross_target_platformosx-64gfortran_version11.0.0target_platformosx-64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=osx&configuration=osx_64_cross_target_platformosx-64gfortran_version11.0.0macos_machinex86_64-apple-darwin13.4.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-64gfortran_version7.5.0target_platformosx-64</td>
+              <td>osx_64_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=osx&configuration=osx_64_cross_target_platformosx-64gfortran_version7.5.0target_platformosx-64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=osx&configuration=osx_64_cross_target_platformosx-64gfortran_version7.5.0macos_machinex86_64-apple-darwin13.4.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-64gfortran_version9.3.0target_platformosx-64</td>
+              <td>osx_64_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=osx&configuration=osx_64_cross_target_platformosx-64gfortran_version9.3.0target_platformosx-64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=osx&configuration=osx_64_cross_target_platformosx-64gfortran_version9.3.0macos_machinex86_64-apple-darwin13.4.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-arm64gfortran_version11.0.0target_platformosx-64</td>
+              <td>osx_64_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=osx&configuration=osx_64_cross_target_platformosx-arm64gfortran_version11.0.0target_platformosx-64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=osx&configuration=osx_64_cross_target_platformosx-arm64gfortran_version11.0.0macos_machinearm64-apple-darwin20.0.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-arm64gfortran_version7.5.0target_platformosx-64</td>
+              <td>osx_64_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=osx&configuration=osx_64_cross_target_platformosx-arm64gfortran_version7.5.0target_platformosx-64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=osx&configuration=osx_64_cross_target_platformosx-arm64gfortran_version7.5.0macos_machinearm64-apple-darwin20.0.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_cross_target_platformosx-arm64gfortran_version9.3.0target_platformosx-64</td>
+              <td>osx_64_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=osx&configuration=osx_64_cross_target_platformosx-arm64gfortran_version9.3.0target_platformosx-64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=osx&configuration=osx_64_cross_target_platformosx-arm64gfortran_version9.3.0macos_machinearm64-apple-darwin20.0.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64_cross_target_platformosx-arm64gfortran_version11.0.0target_platformosx-arm64</td>
+              <td>osx_arm64_cross_target_platformosx-arm64gfortran_version11.0.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=6149&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=osx&configuration=osx_arm64_cross_target_platformosx-arm64gfortran_version11.0.0target_platformosx-arm64" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/gfortran_impl_osx-64-feedstock?branchName=master&jobName=osx&configuration=osx_arm64_cross_target_platformosx-arm64gfortran_version11.0.0" alt="variant">
                 </a>
               </td>
             </tr>
@@ -237,10 +235,10 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-libgfortran4-green.svg)](https://anaconda.org/conda-forge/libgfortran4) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libgfortran4.svg)](https://anaconda.org/conda-forge/libgfortran4) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libgfortran4.svg)](https://anaconda.org/conda-forge/libgfortran4) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libgfortran4.svg)](https://anaconda.org/conda-forge/libgfortran4) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-libgfortran5-green.svg)](https://anaconda.org/conda-forge/libgfortran5) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libgfortran5.svg)](https://anaconda.org/conda-forge/libgfortran5) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libgfortran5.svg)](https://anaconda.org/conda-forge/libgfortran5) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libgfortran5.svg)](https://anaconda.org/conda-forge/libgfortran5) |
 
-Installing gfortran_impl_osx-64
-===============================
+Installing gfortran_impl_osx-arm64
+==================================
 
-Installing `gfortran_impl_osx-64` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `gfortran_impl_osx-arm64` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
@@ -297,17 +295,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating gfortran_impl_osx-64-feedstock
-=======================================
+Updating gfortran_impl_osx-arm64-feedstock
+==========================================
 
-If you would like to improve the gfortran_impl_osx-64 recipe or build a new
+If you would like to improve the gfortran_impl_osx-arm64 recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/gfortran_impl_osx-64-feedstock are
+Note that all branches in the conda-forge/gfortran_impl_osx-arm64-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/build-locally.py
+++ b/build-locally.py
@@ -12,6 +12,10 @@ from argparse import ArgumentParser
 def setup_environment(ns):
     os.environ["CONFIG"] = ns.config
     os.environ["UPLOAD_PACKAGES"] = "False"
+    if ns.debug:
+        os.environ["BUILD_WITH_CONDA_DEBUG"] = "1"
+        if ns.output_id:
+            os.environ["BUILD_OUTPUT_ID"] = ns.output_id
 
 
 def run_docker_build(ns):
@@ -51,6 +55,14 @@ def verify_config(ns):
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--debug",
+        action="store_true",
+        help="Setup debug environment using `conda debug`",
+    )
+    p.add_argument(
+        "--output-id", help="If running debug, specify the output to setup."
+    )
 
     ns = p.parse_args(args=args)
     verify_config(ns)

--- a/recipe/gfortran_test.sh
+++ b/recipe/gfortran_test.sh
@@ -12,4 +12,8 @@ if [[ "$target_platform" == "$cross_target_platform" ]]; then
   "${PREFIX}/bin/${macos_machine}-gfortran" -O3 -fopenmp -ffast-math -o maths maths.f90 -v
   ./maths
   rm -f maths
+
+  "${PREFIX}/bin/${macos_machine}-gfortran" -fopenmp -o omp-threadprivate omp-threadprivate.f90 -v
+  ./omp-threadprivate
+  rm -f omp-threadprivate
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set chost = macos_machine %}
-{% set build_number = 14 %}
+{% set build_number = 15 %}
 {% set version_suffix = "" %}
 
 {% if gfortran_version == "7.5.0" %}
@@ -68,6 +68,7 @@ test:
   files:
     - hello.f90
     - maths.f90
+    - omp-threadprivate.f90
     - gfortran_test.sh
   commands:
     - set -ex

--- a/recipe/omp-threadprivate.f90
+++ b/recipe/omp-threadprivate.f90
@@ -1,0 +1,40 @@
+! @@name:	threadprivate.5f
+! @@type:	F-fixed
+! @@compilable:	yes
+! @@linkable:	yes
+! @@expect:	success
+      PROGRAM INC_GOOD2
+        INTEGER, ALLOCATABLE, SAVE :: A(:)
+        INTEGER, POINTER, SAVE :: PTR
+        INTEGER, SAVE :: I
+        INTEGER, TARGET :: TARG
+        LOGICAL :: FIRSTIN = .TRUE.
+!$OMP   THREADPRIVATE(A, I, PTR)
+
+        ALLOCATE (A(3))
+        A = (/1,2,3/)
+        PTR => TARG
+        I = 5
+
+!$OMP   PARALLEL COPYIN(I, PTR)
+!$OMP     CRITICAL
+            IF (FIRSTIN) THEN
+              TARG = 4           ! Update target of ptr
+              I = I + 10
+              IF (ALLOCATED(A)) A = A + 10
+              FIRSTIN = .FALSE.
+            END IF
+
+            IF (ALLOCATED(A)) THEN
+              PRINT *, 'a = ', A
+            ELSE
+              PRINT *, 'A is not allocated'
+            END IF
+
+            PRINT *, 'ptr = ', PTR
+            PRINT *, 'i = ', I
+            PRINT *
+
+!$OMP     END CRITICAL
+!$OMP   END PARALLEL
+      END PROGRAM INC_GOOD2


### PR DESCRIPTION
In bb2a5bd (Fix linking to libgcc_s, 2020-12-21), the libgfortran.spec
file was fixed so that compiling code with 'threadprivate' OpenMP
directives does not require linking with the internal libgcc_eh library.

To prevent future regressions, add a test to the test script
'gfortran_test.sh' that compiles and runs a Fortran program with OpenMP
threadprivate directives. The program is taken from the OpenMP examples
[1].

Closes conda-forge/gfortran_impl_osx-64-feedstock#36

[1] https://github.com/OpenMP/Examples/blob/master/sources/Example_threadprivate.5.f

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->


<!--
Please add any other relevant info below:
-->
