### PR TITLE
Fix libgfortran run_constrained

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set chost = macos_machine %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 {% if gfortran_version is undefined %}
 {% set gfortran_version = "11.3.0" %}
@@ -182,7 +182,7 @@ outputs:
       string: {{ gfortran_version.replace(".", "_") }}_h{{ PKG_HASH }}_{{ build_number }}
     requirements:
       run:
-        - libgfortran{{ libgfortran_major_version }}
+        - {{ pin_subpackage("libgfortran" ~ libgfortran_major_version, exact=True) }}
 
   - name: libgfortran{{ libgfortran_major_version }}
     version: {{ gfortran_version }}
@@ -213,7 +213,7 @@ outputs:
       run:
         - llvm-openmp >=8.0.0
       run_constrained:
-        - libgfortran {{ libgfortran_version }} *_{{ build_number }}
+        - libgfortran {{ libgfortran_version }} {{ gfortran_version.replace(".", "_") }}_*_{{ build_number }}
 
     test:
       commands:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Fixes https://github.com/conda-forge/gfortran_impl_osx-64-feedstock/issues/73