### PR TITLE
add build offset past earlier libgfortran 5.0 outputs

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set chost = macos_machine %}
-{% set build_number = 2 %}
+{% set build_number = 102 %}
 
 {% if gfortran_version is undefined %}
 {% set gfortran_version = "11.3.0" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,8 @@
 {% set chost = macos_machine %}
-{% set build_number = 102 %}
+{# only reset build_number to 0 if _all_ output versions are increased as well #}
+{% set build_number = 2 %}
+{# use build offset to keep our builds newer than old libgfortran builds from another feedstock #}
+{% set build_offset = 100 %}
 
 {% if gfortran_version is undefined %}
 {% set gfortran_version = "11.3.0" %}
@@ -29,7 +32,7 @@ source:
     - patches/0002-Increase-fallback-min-macOS-version-for-libgcc-to-10.patch   # [gfortran_version == "14.2.0" and cross_target_platform == "osx-64"]
 
 build:
-  number: {{ build_number }}
+  number: {{ build_number + build_offset }}
   # we don't need to cross-compile to osx from anything but osx or linux-64
   skip: true  # [not (osx or linux64)]
 


### PR DESCRIPTION
since this publishes libgfortran 5.0 which also has past builds (up to [build number 32](https://conda-metadata-app.streamlit.app/?q=conda-forge%2Fosx-arm64%2Flibgfortran-5.0.0-12_2_0_hd922786_32.conda)), some installs may prioritize a higher (but older) build of libgfortran over a higher version of libgfortran5.

If you request `libgfortran` directly, e.g. `mamba create -p /tmp/env --dry-run libgfortran`, you get outdated builds:

```
  + libgfortran     5.0.0  12_2_0_hd922786_32  conda-forge      162kB
  + libgfortran5   12.2.0  h0eea778_32         conda-forge        1MB
  + llvm-openmp    20.1.2  hdb05f8b_0          conda-forge     Cached
```

`pixi` seems to resolve slightly differently than mamba, where e.g. `numpy` will resolve to libgfortran5 13 (`-` a pixi env with `numpy`, `+` is the same env with constraint `libgfortran5=14.*`):

```
-libgfortran      5.0.0      13_2_0_hd922786_3     107.6 KiB  conda  https://conda.anaconda.org/conda-forge/
-libgfortran5     13.2.0     hf226fd6_3            974 KiB    conda  https://conda.anaconda.org/conda-forge/
+libgfortran      5.0.0      14_2_0_h6c33f7e_2     152.2 KiB  conda  https://conda.anaconda.org/conda-forge/
+libgfortran5     14.2.0     h6c33f7e_2            787.3 KiB  conda  https://conda.anaconda.org/conda-forge/
```

I _believe_ setting the build offset here so that latest builds of `libgfortran=5.0.0` actually have the highest build number should solve that ambiguity.