### PR TITLE
consistently apply build offset

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set chost = macos_machine %}
 {# only reset build_number to 0 if _all_ output versions are increased as well #}
-{% set build_number = 2 %}
+{% set build_number = 3 %}
 {# use build offset to keep our builds newer than old libgfortran builds from another feedstock #}
-{% set build_offset = 100 %}
+{% set build_number = build_number + 100 %}
 
 {% if gfortran_version is undefined %}
 {% set gfortran_version = "11.3.0" %}
@@ -32,7 +32,7 @@ source:
     - patches/0002-Increase-fallback-min-macOS-version-for-libgcc-to-10.patch   # [gfortran_version == "14.2.0" and cross_target_platform == "osx-64"]
 
 build:
-  number: {{ build_number + build_offset }}
+  number: {{ build_number }}
   # we don't need to cross-compile to osx from anything but osx or linux-64
   skip: true  # [not (osx or linux64)]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,9 @@
 {% set chost = macos_machine %}
-# only reset base_build_number to 0 if _all_ output versions are increased as well
-{% set base_build_number = 3 %}
+# only reset build_number to 0 if _all_ output versions are increased as well
+{% set build_number = 3 %}
 {% set build_offset = 100 %}
 # use build offset to keep our builds newer than old libgfortran builds from another feedstock
-{% set build_number = base_build_number + build_offset %}
+{% set final_build_number = build_number + build_offset %}
 
 {% if gfortran_version is undefined %}
 {% set gfortran_version = "11.3.0" %}
@@ -33,7 +33,7 @@ source:
     - patches/0002-Increase-fallback-min-macOS-version-for-libgcc-to-10.patch   # [gfortran_version == "14.2.0" and cross_target_platform == "osx-64"]
 
 build:
-  number: {{ build_number }}
+  number: {{ final_build_number }}
   # we don't need to cross-compile to osx from anything but osx or linux-64
   skip: true  # [not (osx or linux64)]
 
@@ -183,7 +183,7 @@ outputs:
     target: {{ cross_target_platform }}
     build:
       skip: True  # [target_platform != cross_target_platform]
-      string: {{ gfortran_version.replace(".", "_") }}_h{{ PKG_HASH }}_{{ build_number }}
+      string: {{ gfortran_version.replace(".", "_") }}_h{{ PKG_HASH }}_{{ final_build_number }}
     requirements:
       run:
         - {{ pin_subpackage("libgfortran" ~ libgfortran_major_version, exact=True) }}
@@ -217,7 +217,7 @@ outputs:
       run:
         - llvm-openmp >=8.0.0
       run_constrained:
-        - libgfortran {{ libgfortran_version }} {{ gfortran_version.replace(".", "_") }}_*_{{ build_number }}
+        - libgfortran {{ libgfortran_version }} {{ gfortran_version.replace(".", "_") }}_*_{{ final_build_number }}
 
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,9 @@
 {% set chost = macos_machine %}
-{# only reset build_number to 0 if _all_ output versions are increased as well #}
-{% set build_number = 3 %}
-{# use build offset to keep our builds newer than old libgfortran builds from another feedstock #}
-{% set build_number = build_number + 100 %}
+# only reset base_build_number to 0 if _all_ output versions are increased as well
+{% set base_build_number = 3 %}
+{% set build_offset = 100 %}
+# use build offset to keep our builds newer than old libgfortran builds from another feedstock
+{% set build_number = base_build_number + build_offset %}
 
 {% if gfortran_version is undefined %}
 {% set gfortran_version = "11.3.0" %}


### PR DESCRIPTION
build_number is used in some build strings, so #87 wasn't applied everywhere (the build number was set, but the build string was not for packages with a custom build string, so the new build of e.g. libgfortran wasn't uploaded)

modify build_number variable so it's in a single place and can't be handled inconsistently
